### PR TITLE
KSXMLWriter cleanup, including better pretty-printing

### DIFF
--- a/DOM/KSXMLWriterDOMAdaptor.m
+++ b/DOM/KSXMLWriterDOMAdaptor.m
@@ -147,15 +147,8 @@
     }
     
     
-    if ([self options] & KSXMLWriterDOMAdaptorPrettyPrint)
-    {
-        // pretty printing leaves the writer to make whitespace
-        [[self XMLWriter] startElement:elementName];
-    }
-    else
-    {
-        [[self XMLWriter] startElement:elementName writeInline:YES];
-    }
+    // We leave the writer to do pretty-printing
+    [self.XMLWriter startElement:elementName];
 }
 
 - (DOMNode *)endElementWithDOMElement:(DOMElement *)element;    // returns the next sibling to write

--- a/DOM/KSXMLWriterDOMAdaptor.m
+++ b/DOM/KSXMLWriterDOMAdaptor.m
@@ -82,7 +82,6 @@
     [adaptor writeDOMElement:element];
     
     [adaptor release];
-    [htmlWriter close];
     [htmlWriter release];
     
     return output.string;
@@ -97,7 +96,6 @@
     [adaptor writeDOMElement:element];
     
     [adaptor release];
-    [xmlWriter close];
     [xmlWriter release];
     
     return output.string;

--- a/DOM/KSXMLWriterDOMAdaptor.m
+++ b/DOM/KSXMLWriterDOMAdaptor.m
@@ -419,7 +419,7 @@
         // For text inside HTML elements like <span>, whitespace has meaning, so domn't trim it
         KSXMLWriter *writer = [adaptor XMLWriter];
         NSString *parentElement = [writer topElement];
-        if (!parentElement || ![writer canWriteElementInline:parentElement])
+        if (!parentElement || ![writer.class shouldPrettyPrintElementInline:parentElement])
         {
             static NSCharacterSet *nonWhitespace;
             if (!nonWhitespace) nonWhitespace = [[[NSCharacterSet whitespaceAndNewlineCharacterSet] invertedSet] copy];

--- a/Extras/KSSitemapWriter.m
+++ b/Extras/KSSitemapWriter.m
@@ -83,7 +83,6 @@ NSUInteger const KSSitemapIndexMaxFileSize = 10485760;
 - (void)close;
 {
     [_writer endElement];   // </urlset>
-    [_writer close];
     [_writer release]; _writer = nil;
 }
 
@@ -136,7 +135,6 @@ NSUInteger const KSSitemapIndexMaxFileSize = 10485760;
 - (void)close;
 {
     [_writer endElement];   // </urlset>
-    [_writer close];
     [_writer release]; _writer = nil;
 }
 

--- a/KSHTMLWriter.m
+++ b/KSHTMLWriter.m
@@ -348,9 +348,9 @@ NSString *KSHTMLDoctypeHTML_5 = @"html";
 	}
     else
     {
-        // Embedded scripts should start on their own line for clarity
         // Outdent the script comapred to what's normal
         [self startElement:@"script" writeInline:NO];
+        // Ideally embedded scripts should start on their own line for clarity
         
 		[self decreaseIndentationLevel];
 		[self startNewline];

--- a/KSHTMLWriter.m
+++ b/KSHTMLWriter.m
@@ -47,6 +47,7 @@ NSString *KSHTMLDoctypeHTML_5 = @"html";
     if (self = [super initWithOutputWriter:output])
     {
         self.doctype = KSHTMLDoctypeHTML_5;
+        self.prettyPrint = YES;
         _classNames = [[NSMutableArray alloc] init];
     }
     

--- a/KSHTMLWriter.m
+++ b/KSHTMLWriter.m
@@ -348,13 +348,12 @@ NSString *KSHTMLDoctypeHTML_5 = @"html";
 	}
     else
     {
-        // Outdent the script comapred to what's normal
-        [self startElement:@"script" writeInline:NO];
-        // Ideally embedded scripts should start on their own line for clarity
+        // Outdent the script compared to what's normal. Context will take care of placing on a
+        // new line for us
+        [self startElement:@"script"];
         
 		[self decreaseIndentationLevel];
 		[self startNewline];
-		[self stopWritingInline];
     }
 }
 

--- a/KSHTMLWriter.m
+++ b/KSHTMLWriter.m
@@ -542,8 +542,8 @@ NSString *KSHTMLDoctypeHTML_5 = @"html";
 
 #pragma mark Element Primitives
 
-- (void)startElement:(NSString *)elementName writeInline:(BOOL)writeInline; // for more control
-{
+- (void)willStartElement:(NSString *)elementName {
+    
 #ifdef DEBUG
     NSAssert1([elementName isEqualToString:[elementName lowercaseString]], @"Attempt to start non-lowercase element: %@", elementName);
 #endif
@@ -557,7 +557,8 @@ NSString *KSHTMLDoctypeHTML_5 = @"html";
         [super pushAttribute:@"class" value:class];
     }
     
-    [super startElement:elementName writeInline:writeInline];
+    
+    [super willStartElement:elementName];
 }
 
 - (void)closeEmptyElementTag;               //   />    OR    >    depending on -isXHTML

--- a/KSHTMLWriter.xcodeproj/project.pbxproj
+++ b/KSHTMLWriter.xcodeproj/project.pbxproj
@@ -811,6 +811,7 @@
 				FRAMEWORK_VERSION = A;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "KSHTMLWriterFramework/KSHTMLWriterFramework-Prefix.pch";
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				INFOPLIST_FILE = "KSHTMLWriterFramework/KSHTMLWriterFramework-Info.plist";
 				INSTALL_PATH = "@executable_path/../Frameworks/";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/KSHTMLWriter.xcodeproj/project.pbxproj
+++ b/KSHTMLWriter.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		27E32EB61B0340B5002ED4A2 /* KSWriter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27CF37B71B024BBC00DEABC4 /* KSWriter.framework */; };
 		27E32EFC1B0383F0002ED4A2 /* Stringification.testdata in Resources */ = {isa = PBXBuildFile; fileRef = 27E32EFB1B0383F0002ED4A2 /* Stringification.testdata */; };
 		27E32F001B038415002ED4A2 /* StringificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 27E32EFF1B038415002ED4A2 /* StringificationTests.m */; };
+		27EE52EB1B32B4300039EEDE /* KSHTMLWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 27EE52EA1B32B4300039EEDE /* KSHTMLWriterTests.m */; };
 		9FC4242E15F57A0F001B9220 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22352B9314C6FCB00031F5DD /* Cocoa.framework */; };
 		9FC4243415F57A0F001B9220 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9FC4243215F57A0F001B9220 /* InfoPlist.strings */; };
 		9FC4243D15F5801E001B9220 /* KSCSSWriter.m in Sources */ = {isa = PBXBuildFile; fileRef = 22352BC114C6FD260031F5DD /* KSCSSWriter.m */; };
@@ -145,6 +146,7 @@
 		27CF37CD1B024EE000DEABC4 /* KSHTMLWriterFramework_Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KSHTMLWriterFramework_Tests.m; sourceTree = "<group>"; };
 		27E32EFB1B0383F0002ED4A2 /* Stringification.testdata */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Stringification.testdata; sourceTree = "<group>"; };
 		27E32EFF1B038415002ED4A2 /* StringificationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StringificationTests.m; sourceTree = "<group>"; };
+		27EE52EA1B32B4300039EEDE /* KSHTMLWriterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSHTMLWriterTests.m; sourceTree = "<group>"; };
 		9FC4242D15F57A0F001B9220 /* KSHTMLWriterFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KSHTMLWriterFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9FC4243115F57A0F001B9220 /* KSHTMLWriterFramework-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "KSHTMLWriterFramework-Info.plist"; sourceTree = "<group>"; };
 		9FC4243315F57A0F001B9220 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -293,6 +295,7 @@
 				22C91F0214F7BDBC00FCFF8F /* KSHTMLWriterSnippetTests.m */,
 				22C91F0414F7BDBC00FCFF8F /* KSXMLWriterCompoundTests.m */,
 				22C91F0514F7BDBC00FCFF8F /* KSXMLWriterTests.m */,
+				27EE52EA1B32B4300039EEDE /* KSHTMLWriterTests.m */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -597,6 +600,7 @@
 				27CF37DD1B02571B00DEABC4 /* KSHTMLWriterNormalSnippetTests.m in Sources */,
 				27CF37DB1B02566200DEABC4 /* KSHTMLWriterSnippetTests.m in Sources */,
 				27CF37D71B0253AB00DEABC4 /* ECParameterisedTestCase.m in Sources */,
+				27EE52EB1B32B4300039EEDE /* KSHTMLWriterTests.m in Sources */,
 				27E32F001B038415002ED4A2 /* StringificationTests.m in Sources */,
 				27CF37CE1B024EE000DEABC4 /* KSHTMLWriterFramework_Tests.m in Sources */,
 			);

--- a/KSStringXMLEntityEscaping.m
+++ b/KSStringXMLEntityEscaping.m
@@ -26,14 +26,6 @@
 #import "KSStringXMLEntityEscaping.h"
 
 
-@interface KSXMLWriter (KSXMLWriterSecretsIKnow)
-- (void)writeStringByEscapingXMLEntities:(NSString *)string escapeQuot:(BOOL)escapeQuotes;
-@end
-
-
-#pragma mark -
-
-
 @implementation NSString (KSStringXMLEntityEscaping)
 
 #pragma mark XML

--- a/KSStringXMLEntityEscaping.m
+++ b/KSStringXMLEntityEscaping.m
@@ -37,9 +37,9 @@
 
 - (NSString *)stringByEscapingXMLEntities:(NSDictionary *)entities
 {
-	NSString *result = NSMakeCollectable(CFXMLCreateStringByEscapingEntities(NULL,
-                                                                             (CFStringRef)self,
-                                                                             (CFMutableDictionaryRef)entities));
+	NSString *result = (NSString *)CFXMLCreateStringByEscapingEntities(NULL,
+                                                                       (CFStringRef)self,
+                                                                       (CFMutableDictionaryRef)entities);
 	return [result autorelease];
 }
 
@@ -55,9 +55,9 @@
 	return result;
     */
 	   
-	NSString *result = NSMakeCollectable(CFXMLCreateStringByUnescapingEntities(NULL,
-                                                                               (CFStringRef)self,
-                                                                               (CFDictionaryRef)entities));
+    NSString *result = (NSString *)CFXMLCreateStringByUnescapingEntities(NULL,
+                                                                         (CFStringRef)self,
+                                                                         (CFDictionaryRef)entities);
 	return [result autorelease];
     
 }

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -129,7 +129,7 @@
  - You can call \c -resetPrettyPrinting to make use of the mechanism described above so as to force
  the writer not to insert a newline for a moment.
  
- - For HTML, some elements want to be written inline anyway for optimum prettiness. E.g. \c <em> tags
+ - For HTML, some elements want to be written inline anyway for optimum prettiness. E.g. \c EM tags
  inside of a paragraph. `shouldPrettyPrintElementInline` is consulted to find out if that is the
  case, so as to bypass the newline behaviour.
  

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -44,8 +44,7 @@
 #pragma mark Creating an XML Writer
 
 // .encoding is taken from the writer. If output writer is nil, defaults to UTF-8
-// Designated initializer
-- (id)initWithOutputWriter:(KSWriter *)output;
+- (id)initWithOutputWriter:(KSWriter *)output NS_DESIGNATED_INITIALIZER;
 
 
 #pragma mark Writer Status

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -93,7 +93,11 @@
 
 
 #pragma mark Whitespace
-//  Writes a newline character and the tabs to match -indentationLevel. Normally newlines are automatically written for you; call this if you need an extra one.
+
+/**
+ Writes a newline character. If pretty-printing is turned on, includes tabs to match \c -indentationLevel.
+ Normally newlines are automatically written for you; call this if you need an extra one.
+ */
 - (void)startNewline;
 
 

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -113,7 +113,7 @@
 
 #pragma mark Indentation
 // Setting the indentation level does not write to the context in any way. It is up to methods that actually do some writing to respect the indent level. e.g. starting a new line should indent that line to match.
-@property(nonatomic) NSInteger indentationLevel;
+@property(nonatomic) NSUInteger indentationLevel;
 - (void)increaseIndentationLevel;
 
 /**

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -35,8 +35,6 @@
     NSMutableArray  *_openElements;
     BOOL            _elementIsEmpty;
     NSUInteger      _inlineWritingLevel;    // the number of open elements at which inline writing began
-        
-    NSInteger   _indentation;
 }
 
 #pragma mark Creating an XML Writer

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -143,7 +143,14 @@
 - (void)closeEmptyElementTag;             
 
 
-#pragma mark Inline Writing
+#pragma mark Pretty Printing
+
+/**
+ Whether the receiver should create human-friendly output by indenting elements, and placing them on
+ a newline. The default is \c NO, but \c KSHTMLWriter does the opposite, to make pretty-printing on
+ by default.
+ */
+@property(nonatomic) BOOL prettyPrint;
 
 - (BOOL)isWritingInline;
 - (void)startWritingInline;

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -47,9 +47,6 @@
 // Designated initializer
 - (id)initWithOutputWriter:(KSWriter *)output;
 
-// Use this if you need to specify a custom encoding
-+ (instancetype)writerWithOutputWriter:(KSWriter *)output encoding:(NSStringEncoding)encoding;
-
 
 #pragma mark Writer Status
 - (void)close;  // calls -flush, then releases most ivars such as _writer

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -29,13 +29,6 @@
 
 
 @interface KSXMLWriter : NSObject
-{
-  @private
-    KSXMLAttributes   *_attributes;
-    NSMutableArray  *_openElements;
-    BOOL            _elementIsEmpty;
-    NSUInteger      _inlineWritingLevel;    // the number of open elements at which inline writing began
-}
 
 #pragma mark Creating an XML Writer
 

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -166,9 +166,20 @@
 + (BOOL)shouldPrettyPrintElementInline:(NSString *)element;
 
 
-#pragma mark String Encoding
-- (void)writeString:(NSString *)string range:(NSRange)range; // anything outside the receiver's encoding gets escaped. primitive
-- (void)writeString:(NSString *)string; // convenience
+#pragma mark Output
+
+/**
+ This is the primitive API through which all output is channeled. The requested \c range of \c string
+ is sent through to \c outputWriter. Any characters which aren't supported by the receiver's
+ \c encoding are XML escaped before sending through.
+ */
+- (void)writeString:(NSString *)string range:(NSRange)range;
+
+/**
+ Convenience that calls straight through to \c writeString:range: requesting the whole string be
+ written
+ */
+- (void)writeString:(NSString *)string;
 
 /**
  Automatically taken from the \c outputWriter. Defaults to UTF8 if there is no output
@@ -180,7 +191,6 @@
 + (BOOL)isStringEncodingAvailable:(NSStringEncoding)encoding;
 
 
-#pragma mark Output
 @property(readonly) KSWriter *outputWriter;
 
 

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -36,11 +36,6 @@
 - (id)initWithOutputWriter:(KSWriter *)output NS_DESIGNATED_INITIALIZER;
 
 
-#pragma mark Writer Status
-- (void)close;  // calls -flush, then releases most ivars such as _writer
-- (void)flush;  // if there's anything waiting to be lazily written, forces it to write now. For subclasses to implement
-
-
 #pragma mark Document
 
 /**

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -167,7 +167,7 @@
 
 
 #pragma mark String Encoding
-@property(nonatomic, readonly) NSStringEncoding encoding;   // default is UTF-8
+@property(nonatomic, readonly) NSStringEncoding encoding;
 - (void)writeString:(NSString *)string range:(NSRange)range; // anything outside the receiver's encoding gets escaped. primitive
 - (void)writeString:(NSString *)string; // convenience
 + (BOOL)isStringEncodingAvailable:(NSStringEncoding)encoding;   // we support ASCII, UTF8, ISO Latin 1, and Unicode at present

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -37,8 +37,6 @@
     NSUInteger      _inlineWritingLevel;    // the number of open elements at which inline writing began
         
     NSInteger   _indentation;
-    
-    NSStringEncoding    _encoding;
 }
 
 #pragma mark Creating an XML Writer

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -156,8 +156,13 @@
 - (void)startWritingInline;
 - (void)stopWritingInline;
 
-// Class method is a general rule; instance method takes into account current indent level etc.
-- (BOOL)canWriteElementInline:(NSString *)element;
+/**
+ When starting an element with \c prettyPrint turned on, this gets called to decide if \c element
+ should be written inline, or begin on a new line.
+ 
+ The default implementation returns \c NO. \c KSHTMLWriter overrides to know about a variety of
+ common HTML elements.
+ */
 + (BOOL)shouldPrettyPrintElementInline:(NSString *)element;
 
 

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -195,7 +195,6 @@
 
 // These simple methods make up the bulk of element writing. You can start as many elements at a time as you like in order to nest them. Calling -endElement will automatically know the right close tag to write etc.
 - (void)startElement:(NSString *)elementName;
-- (void)startElement:(NSString *)elementName writeInline:(BOOL)writeInline; // for more control
 - (void)endElement;
 
 - (void)startCDATA;

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -167,10 +167,17 @@
 
 
 #pragma mark String Encoding
-@property(nonatomic, readonly) NSStringEncoding encoding;
 - (void)writeString:(NSString *)string range:(NSRange)range; // anything outside the receiver's encoding gets escaped. primitive
 - (void)writeString:(NSString *)string; // convenience
-+ (BOOL)isStringEncodingAvailable:(NSStringEncoding)encoding;   // we support ASCII, UTF8, ISO Latin 1, and Unicode at present
+
+/**
+ Automatically taken from the \c outputWriter. Defaults to UTF8 if there is no output
+ */
+@property(nonatomic, readonly) NSStringEncoding encoding;
+
+/** we support ASCII, UTF8, ISO Latin 1, and Unicode at present
+ */
++ (BOOL)isStringEncodingAvailable:(NSStringEncoding)encoding;
 
 
 #pragma mark Output

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -239,12 +239,7 @@
     
     if (self.prettyPrint) {
         
-        NSInteger indentationLevel = [self indentationLevel];
-        if (indentationLevel < 0)
-        {
-            NSLog(@"KSXMLWriter: Negative Indentation Level!");
-            indentationLevel = 0;    // prevent accidental overruns if negative
-        }
+        NSUInteger indentationLevel = [self indentationLevel];
         for (NSUInteger i = 0; i < indentationLevel; i++)
         {
             [self writeString:@"\t"];

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -27,27 +27,6 @@
 
 
 @interface KSXMLWriter ()
-
-#pragma mark Element Primitives
-
-//   attribute="value"
-- (void)writeAttribute:(NSString *)attribute
-                 value:(id)value;
-
-//  Starts tracking -writeString: calls to see if element is empty
-- (void)didStartElement;
-
-//  >
-//  Then increases indentation level
-- (void)closeStartTag;
-
-//   />
-- (void)closeEmptyElementTag;             
-
-- (void)writeEndTag:(NSString *)tagName;    // primitive version that ignores open elements stack
-
-- (BOOL)elementCanBeEmpty:(NSString *)tagName;  // YES for everything in pure XML
-
 @end
 
 
@@ -247,6 +226,11 @@
     return result;
 }
 
+/**
+ Performs the raw writing of an attribute and its value:
+ 
+ \c attribute="value"
+ */
 - (void)writeAttribute:(NSString *)attribute
                  value:(id)value;
 {
@@ -378,28 +362,50 @@
 
 #pragma mark Element Primitives
 
-- (void)didStartElement;
-{
+/**
+ Called each time an element is started. Begins tracking \c -writeString: calls to see if element is empty
+ */
+- (void)didStartElement {
+    
     // For elements which can't be empty, might as well go ahead and close the start tag now
     _elementIsEmpty = [self elementCanBeEmpty:[self topElement]];
     if (!_elementIsEmpty) [self closeStartTag];
 }
 
-- (void)closeStartTag;
-{
+/**
+ Writes the raw \c > character that marks the close of a _tag_ (not the element, the tag)
+ */
+- (void)closeStartTag {
     [self writeString:@">"];
 }
 
-- (void)closeEmptyElementTag; { [self writeString:@" />"]; }
+/**
+ Much like \c closeStartTag, but for ending an element which has been found to be empty:
+ 
+ \c  />
+ */
+- (void)closeEmptyElementTag {
+    [self writeString:@" />"];
+}
 
-- (void)writeEndTag:(NSString *)tagName;    // primitive version that ignores open elements stack
-{
+/**
+ Primitive method that writes an end tag, ignoring the open elements stack
+ */
+- (void)writeEndTag:(NSString *)tagName {
+    
     [self writeString:@"</"];
     [self writeString:tagName];
     [self writeString:@">"];
 }
 
-- (BOOL)elementCanBeEmpty:(NSString *)tagName; { return YES; }
+/**
+ Whether we're allowed to not bother with an end tag for a particular empty element. For pure XML
+ all elements are fine like this, so we return \c YES, but the HTML Writer subclasses to opt out
+ unsupported elements.
+ */
+- (BOOL)elementCanBeEmpty:(NSString *)tagName {
+    return YES;
+}
 
 #pragma mark Inline Writing
 

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -518,9 +518,9 @@ static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;
 			encoding == NSUnicodeStringEncoding);
 }
 
-- (void)writeString:(NSString *)string range:(NSRange)nsrange;
-{
-	NSParameterAssert(nil != string); 
+- (void)writeString:(NSString *)string range:(NSRange)nsrange {
+	NSParameterAssert(string);
+    
     // Is this string some element content? If so, the element is no longer empty so must close the tag and mark as such
     if (_elementIsEmpty && [string length])
     {

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -71,25 +71,12 @@
 
 - (void)dealloc
 {
-    [self close];
-    
     [_openElements release];
     [_attributes release];
     [_doctype release];
     
     [super dealloc];
 }
-
-#pragma mark Writer Status
-
-- (void)close;
-{
-    [self flush];
-    
-    [_outputWriter release]; _outputWriter = nil;
-}
-
-- (void)flush; { }
 
 #pragma mark Document
 

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -63,8 +63,7 @@
 
 #pragma mark Init & Dealloc
 
-- (id)initWithOutputWriter:(KSWriter *)output;  // designated initializer
-{    
+- (id)initWithOutputWriter:(KSWriter *)output {
     if (self = [super init])
     {
         _output = [output retain];

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -311,16 +311,6 @@
 
 #pragma mark Elements Stack
 
-- (BOOL)canWriteElementInline:(NSString *)element;
-{
-    // In standard XML, no elements can be inline, unless it's the start of the doc
-    return (_inlineWritingLevel == 0 || [[self class] shouldPrettyPrintElementInline:element]);
-}
-
-+ (BOOL)shouldPrettyPrintElementInline:(NSString *)element {
-    return NO;
-}
-
 - (NSArray *)openElements; { return [[_openElements copy] autorelease]; }
 
 - (NSUInteger)openElementsCount;
@@ -418,6 +408,18 @@
 }
 
 - (void)stopWritingInline; { _inlineWritingLevel = NSNotFound; }
+
+- (BOOL)canWriteElementInline:(NSString *)element;
+{
+    // In standard XML, no elements can be inline, unless it's the start of the doc
+    return (_inlineWritingLevel == 0 || [[self class] shouldPrettyPrintElementInline:element]);
+}
+
++ (BOOL)shouldPrettyPrintElementInline:(NSString *)element {
+    return NO;
+}
+
+#pragma mark String Encoding
 
 static NSCharacterSet *sCharactersToEntityEscapeWithQuot;
 static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -59,7 +59,12 @@
 #pragma mark -
 
 
-@implementation KSXMLWriter
+@implementation KSXMLWriter {
+    KSXMLAttributes   *_attributes;
+    NSMutableArray  *_openElements;
+    BOOL            _elementIsEmpty;
+    NSUInteger      _inlineWritingLevel;    // the number of open elements at which inline writing began
+}
 
 #pragma mark Init & Dealloc
 

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -317,8 +317,7 @@
     return (_inlineWritingLevel == 0 || [[self class] shouldPrettyPrintElementInline:element]);
 }
 
-+ (BOOL)shouldPrettyPrintElementInline:(NSString *)element;
-{
++ (BOOL)shouldPrettyPrintElementInline:(NSString *)element {
     return NO;
 }
 

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -71,6 +71,7 @@
 
 - (void)dealloc
 {
+    [_outputWriter release];
     [_openElements release];
     [_attributes release];
     [_doctype release];

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -302,8 +302,6 @@
 
 #pragma mark Indentation
 
-@synthesize indentationLevel = _indentation;
-
 - (void)increaseIndentationLevel;
 {
     self.indentationLevel++;

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -66,7 +66,7 @@
 - (id)initWithOutputWriter:(KSWriter *)output {
     if (self = [super init])
     {
-        _output = [output retain];
+        _outputWriter = [output retain];
         
         _encoding = (output ? output.encoding : NSUTF8StringEncoding);
         if (![[self class] isStringEncodingAvailable:_encoding])
@@ -102,7 +102,7 @@
 {
     [self flush];
     
-    [_output release]; _output = nil;
+    [_outputWriter release]; _outputWriter = nil;
 }
 
 - (void)flush; { }
@@ -552,7 +552,7 @@ static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;
             if (written)
             {
                 NSRange validRange = NSMakeRange(range.location, written);
-                [_output writeString:string range:validRange];
+                [_outputWriter writeString:string range:validRange];
             }
             
             // Convert the invalid char
@@ -560,18 +560,18 @@ static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;
             switch (ch)
             {
                     // If we encounter a special character with a symbolic entity, use that
-                case 160:	[_output writeString:@"&nbsp;"];      break;
-                case 169:	[_output writeString:@"&copy;"];      break;
-                case 174:	[_output writeString:@"&reg;"];       break;
-                case 8211:	[_output writeString:@"&ndash;"];     break;
-                case 8212:	[_output writeString:@"&mdash;"];     break;
-                case 8364:	[_output writeString:@"&euro;"];      break;
+                case 160:	[_outputWriter writeString:@"&nbsp;"];      break;
+                case 169:	[_outputWriter writeString:@"&copy;"];      break;
+                case 174:	[_outputWriter writeString:@"&reg;"];       break;
+                case 8211:	[_outputWriter writeString:@"&ndash;"];     break;
+                case 8212:	[_outputWriter writeString:@"&mdash;"];     break;
+                case 8364:	[_outputWriter writeString:@"&euro;"];      break;
                     
                     // Otherwise, use the decimal unicode value.
                 default:
 				{
 					NSString *escaped = [NSString stringWithFormat:@"&#%d;",ch];
-					[_output writeString:escaped];   break;
+					[_outputWriter writeString:escaped];   break;
 				}
             }
             
@@ -582,23 +582,19 @@ static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;
         else if (range.location == 0)
         {
             // Efficient route for if entire string can be written
-            [_output writeString:string range:nsrange];
+            [_outputWriter writeString:string range:nsrange];
             break;
         }
         else
         {
             // Write what remains
-            [_output writeString:string range:NSMakeRange(range.location, range.length)];
+            [_outputWriter writeString:string range:NSMakeRange(range.location, range.length)];
             break;
         }
     }
 }
 
 - (void)writeString:(NSString *)string; { [self writeString:string range:NSMakeRange(0, string.length)]; }
-
-#pragma mark Output
-
-@synthesize outputWriter = _output;
 
 #pragma mark -
 #pragma mark Pre-Blocks Support

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -596,13 +596,10 @@ static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;
 #pragma mark -
 #pragma mark Pre-Blocks Support
 
-- (void)startElement:(NSString *)elementName;
-{
-    [self startElement:elementName writeInline:[self canWriteElementInline:elementName]];
-}
-
-- (void)startElement:(NSString *)elementName writeInline:(BOOL)writeInline;
-{
+- (void)startElement:(NSString *)elementName {
+    
+    BOOL writeInline = !self.prettyPrint || [self canWriteElementInline:elementName];
+    
     // Can only write suitable tags inline if containing element also allows it
     if (!writeInline)
     {

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -395,7 +395,7 @@
     return YES;
 }
 
-#pragma mark Inline Writing
+#pragma mark Pretty Printing
 
 /*! How it works:
  *

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -524,7 +524,7 @@ static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;
     // Is this string some element content? If so, the element is no longer empty so must close the tag and mark as such
     if (_elementIsEmpty && [string length])
     {
-        _elementIsEmpty = NO;   // comes first to avoid infinte recursion
+        _elementIsEmpty = NO;   // comes first to avoid infinite recursion
         [self closeStartTag];
     }
     

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -86,15 +86,6 @@
 
 - (id)init; { return [self initWithOutputWriter:nil]; }
 
-+ (instancetype)writerWithOutputWriter:(KSWriter *)output encoding:(NSStringEncoding)encoding;
-{
-	return [[[self alloc] initWithOutputWriter:[KSWriter writerWithEncoding:encoding block:^(NSString *string, NSRange range) {
-        
-		[output writeString:string range:range];
-        
-	}]] autorelease];
-}
-
 - (void)dealloc
 {
     [self close];

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -233,19 +233,22 @@
 
 #pragma mark Whitespace
 
-- (void)startNewline;   // writes a newline character and the tabs to match -indentationLevel
+- (void)startNewline
 {
     [self writeString:@"\n"];
     
-    NSInteger indentationLevel = [self indentationLevel];
-	if (indentationLevel < 0)
-	{
-		NSLog(@"KSXMLWriter: Negative Indentation Level!");
-		indentationLevel = 0;    // prevent accidental overruns if negative
-	}
-	for (NSUInteger i = 0; i < indentationLevel; i++)
-    {
-        [self writeString:@"\t"];
+    if (self.prettyPrint) {
+        
+        NSInteger indentationLevel = [self indentationLevel];
+        if (indentationLevel < 0)
+        {
+            NSLog(@"KSXMLWriter: Negative Indentation Level!");
+            indentationLevel = 0;    // prevent accidental overruns if negative
+        }
+        for (NSUInteger i = 0; i < indentationLevel; i++)
+        {
+            [self writeString:@"\t"];
+        }
     }
 }
 

--- a/Tests/Classes/KSHTMLWriterTests.m
+++ b/Tests/Classes/KSHTMLWriterTests.m
@@ -1,0 +1,49 @@
+//
+//  KSHTMLWriterTests.m
+//  KSHTMLWriter
+//
+//  Created by Mike on 18/06/2015.
+//  Copyright (c) 2015 Karelia Software. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+#import <XCTest/XCTest.h>
+
+#import "KSHTMLWriter.h"
+
+
+@interface KSHTMLWriterTests : XCTestCase
+
+@end
+
+
+@implementation KSHTMLWriterTests {
+    KSWriter* output;
+    KSHTMLWriter* writer;
+}
+
+- (void)setUp {
+    [super setUp];
+    
+    output = [KSWriter stringWriterWithEncoding:NSUTF8StringEncoding];
+    writer = [[KSHTMLWriter alloc] initWithOutputWriter:output];
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testCommentAtEndOfElement {
+    
+    [writer writeElement:@"div" content:^{
+        [writer writeElement:@"p" text:@"text"];
+    }];
+    
+    [writer writeComment:@"comment"];
+    
+    XCTAssertEqualObjects(output.string, @"<div>\n\t<p>text</p>\n</div><!--comment-->",
+                          @"Comment should be directly after end of element; not on a new line");
+}
+
+@end

--- a/Tests/Classes/KSHTMLWriterTests.m
+++ b/Tests/Classes/KSHTMLWriterTests.m
@@ -59,4 +59,12 @@
     XCTAssertEqualObjects(output.string, @"<p>Test <b>strong</b>. Test <i>often</i>.</p>");
 }
 
+- (void)testEmbeddedJavascriptPrettyPrinting {
+    [writer writeJavascript:@"// your script goes here" useCDATA:NO];
+    
+    XCTAssertEqualObjects(output.string, @"<script>\n// your script goes here\n</script>",
+                          @"The script contents go on their own line, level with the <script> tag. "
+                          @"The </script> tag goes down onto its own line too");
+}
+
 @end

--- a/Tests/Classes/KSHTMLWriterTests.m
+++ b/Tests/Classes/KSHTMLWriterTests.m
@@ -46,4 +46,17 @@
                           @"Comment should be directly after end of element; not on a new line");
 }
 
+- (void)testPrettyPrintedParagraph {
+    
+    [writer writeElement:@"p" content:^{
+        [writer writeCharacters:@"Test "];
+        [writer writeElement:@"b" text:@"strong"];
+        [writer writeCharacters:@". Test "];
+        [writer writeElement:@"i" text:@"often"];
+        [writer writeCharacters:@"."];
+    }];
+    
+    XCTAssertEqualObjects(output.string, @"<p>Test <b>strong</b>. Test <i>often</i>.</p>");
+}
+
 @end

--- a/Tests/Classes/KSXMLWriterCompoundTests.m
+++ b/Tests/Classes/KSXMLWriterCompoundTests.m
@@ -89,6 +89,7 @@ typedef enum
     NSDictionary* test = self.parameterisedTestDataItem;
     KSWriter* output = [KSWriter stringWriterWithEncoding:NSUnicodeStringEncoding];
     KSXMLWriter* writer = [[class alloc] initWithOutputWriter:output];
+    writer.prettyPrint = YES;
 
     NSArray* actions = [test objectForKey:@"actions"];
     NSString* expected = [test objectForKey:expectedKey];

--- a/Tests/Classes/KSXMLWriterTests.m
+++ b/Tests/Classes/KSXMLWriterTests.m
@@ -160,6 +160,8 @@
     
 }
 
+#pragma mark Comments
+
 - (void)testWriteComment
 {
     // TODO could expand this to include a list of all entities
@@ -171,6 +173,19 @@
     
     NSString* generated = [output string];
     XCTAssertEqualObjects(generated, @"<foo><!--this is a comment-->this is not a comment<!--this is another comment--></foo>");
+}
+
+- (void)testCommentAtEndOfElement {
+    writer.prettyPrint = YES;
+    
+    [writer writeElement:@"foo" content:^{
+        [writer writeElement:@"bar" text:@"text"];
+    }];
+    
+    [writer writeComment:@"comment"];
+    
+    XCTAssertEqualObjects(output.string, @"<foo>\n\t<bar>text</bar>\n</foo><!--comment-->",
+                          @"Comment should be directly after end of element; not on a new line");
 }
 
 - (void)testStartDocument

--- a/Tests/Classes/KSXMLWriterTests.m
+++ b/Tests/Classes/KSXMLWriterTests.m
@@ -204,4 +204,23 @@
     XCTAssertEqualObjects(output.string, @"<foo />\n<bar />");
 }
 
+- (void)testNestedElements {
+    
+    [writer writeElement:@"foo" content:^{
+        [writer writeElement:@"bar" content:nil];
+    }];
+    
+    XCTAssertEqualObjects(output.string, @"<foo><bar /></foo>");
+}
+
+- (void)testNestedElementsPrettyPrinted {
+    writer.prettyPrint = YES;
+    
+    [writer writeElement:@"foo" content:^{
+        [writer writeElement:@"bar" content:nil];
+    }];
+    
+    XCTAssertEqualObjects(output.string, @"<foo>\n\t<bar />\n</foo>");
+}
+
 @end

--- a/Tests/Classes/KSXMLWriterTests.m
+++ b/Tests/Classes/KSXMLWriterTests.m
@@ -173,7 +173,8 @@
 
 - (void)testStartDocument
 {
-    [writer startDocumentWithDocType:@"some-type"];
+    writer.doctype = @"some-type";
+    [writer writeDoctypeDeclaration];
     [writer writeElement:@"foo" attributes:nil content:^{
         [writer writeCharacters:@"bar"];
     }];

--- a/Tests/Classes/KSXMLWriterTests.m
+++ b/Tests/Classes/KSXMLWriterTests.m
@@ -30,6 +30,8 @@
     writer = [[KSXMLWriter alloc] initWithOutputWriter:output];
 }
 
+#pragma mark Single Elements
+
 - (void)testNoAction
 {
     NSString* generated = [output string];
@@ -182,6 +184,24 @@
     NSString* generated = [output string];
     XCTAssertEqualObjects(generated, @"<!DOCTYPE some-type>\n<foo>bar</foo>");
     
+}
+
+#pragma mark Multiple Elements
+
+- (void)testSiblingElements {
+    [writer writeElement:@"foo" content:nil];
+    [writer writeElement:@"bar" content:nil];
+    
+    XCTAssertEqualObjects(output.string, @"<foo /><bar />");
+}
+
+- (void)testSiblingElementsPrettyPrinted {
+    writer.prettyPrint = YES;
+    
+    [writer writeElement:@"foo" content:nil];
+    [writer writeElement:@"bar" content:nil];
+    
+    XCTAssertEqualObjects(output.string, @"<foo />\n<bar />");
 }
 
 @end

--- a/Tests/Classes/KSXMLWriterTests.m
+++ b/Tests/Classes/KSXMLWriterTests.m
@@ -160,8 +160,6 @@
     
 }
 
-#pragma mark Comments
-
 - (void)testWriteComment
 {
     // TODO could expand this to include a list of all entities
@@ -173,19 +171,6 @@
     
     NSString* generated = [output string];
     XCTAssertEqualObjects(generated, @"<foo><!--this is a comment-->this is not a comment<!--this is another comment--></foo>");
-}
-
-- (void)testCommentAtEndOfElement {
-    writer.prettyPrint = YES;
-    
-    [writer writeElement:@"foo" content:^{
-        [writer writeElement:@"bar" text:@"text"];
-    }];
-    
-    [writer writeComment:@"comment"];
-    
-    XCTAssertEqualObjects(output.string, @"<foo>\n\t<bar>text</bar>\n</foo><!--comment-->",
-                          @"Comment should be directly after end of element; not on a new line");
 }
 
 - (void)testStartDocument


### PR DESCRIPTION
The highlights:
- Added `prettyPrint` property a single handy place to turn off pretty-printing when we don't want it. Up till now the system has always assumed you want pretty-printing and not given a decent way out
- Simplified controls and better docs over how pretty works, and how you can control it
- Private ivars
- XML/HTML Contexts no longer have `close` or `flush` methods; they were just adding confusion
- Safer control over indentation
- More tests
- Stopped using `NSMakeCollectable` so we could go ARC if wanted
