### PR TITLE
-addAttribute:value:

### DIFF
--- a/KSHTMLWriter.m
+++ b/KSHTMLWriter.m
@@ -234,12 +234,11 @@ NSString *KSHTMLDoctypeHTML_5 = @"html";
 - (void)startAnchorElementWithHref:(NSString *)href title:(NSString *)titleString target:(NSString *)targetString rel:(NSString *)relString;
 {
     // TODO: Remove this method once Sandvox no longer needs it
-	if (href) [self pushAttribute:@"href" value:href];
-	if (targetString) [self pushAttribute:@"target" value:targetString];
-	if (titleString) [self pushAttribute:@"title" value:titleString];
-	if (relString) [self pushAttribute:@"rel" value:relString];
-	
     [self startElement:@"a"];
+    if (href) [self addAttribute:@"href" value:href];
+    if (targetString) [self addAttribute:@"target" value:targetString];
+    if (titleString) [self addAttribute:@"title" value:titleString];
+    if (relString) [self addAttribute:@"rel" value:relString];
 }
 
 - (void)writeAnchorElementWithHref:(NSString *)href title:(NSString *)titleString target:(NSString *)targetString rel:(NSString *)relString content:(void (^)(void))content;
@@ -258,13 +257,12 @@ NSString *KSHTMLDoctypeHTML_5 = @"html";
                     width:(id)width
                    height:(id)height;
 {
-    [self pushAttribute:@"src" value:src];
-    [self pushAttribute:@"alt" value:alt];
-    if (width) [self pushAttribute:@"width" value:width];
-    if (height) [self pushAttribute:@"height" value:height];
-    
-    [self startElement:@"img"];
-    [self endElement];
+    [self writeElement:@"img" content:^{
+        [self addAttribute:@"src" value:src];
+        [self addAttribute:@"alt" value:alt];
+        if (width) [self addAttribute:@"width" value:width];
+        if (height) [self addAttribute:@"height" value:height];
+    }];
 }
 
 #pragma mark Link
@@ -275,14 +273,13 @@ NSString *KSHTMLDoctypeHTML_5 = @"html";
                     title:(NSString *)title
                     media:(NSString *)media;
 {
-    if (rel) [self pushAttribute:@"rel" value:rel];
-    if (type) [self pushAttribute:@"type" value:type];
-    [self pushAttribute:@"href" value:href];
-    if (title) [self pushAttribute:@"title" value:title];
-    if (media) [self pushAttribute:@"media" value:media];
-    
-    [self startElement:@"link"];
-    [self endElement];
+    [self writeElement:@"link" content:^{
+        if (rel) [self addAttribute:@"rel" value:rel];
+        if (type) [self addAttribute:@"type" value:type];
+        [self addAttribute:@"href" value:href];
+        if (title) [self addAttribute:@"title" value:title];
+        if (media) [self addAttribute:@"media" value:media];
+    }];
 }
 
 - (void)writeLinkToStylesheet:(NSString *)href
@@ -308,9 +305,9 @@ NSString *KSHTMLDoctypeHTML_5 = @"html";
 
 - (void)writeJavascriptWithSrc:(NSString *)src charset:(NSString *)charset;	// src may be nil
 {    
-    if (charset) [self pushAttribute:@"charset" value:charset];
     [self startJavascriptElementWithSrc:src];
-	if (!src) [self increaseIndentationLevel];    // compensate for -decreaseIndentationLevel
+    if (charset) [self addAttribute:@"charset" value:charset];
+    if (!src) [self increaseIndentationLevel];    // compensate for -decreaseIndentationLevel
     [self endElement];
 }
 
@@ -334,25 +331,24 @@ NSString *KSHTMLDoctypeHTML_5 = @"html";
 
 - (void)startJavascriptElementWithSrc:(NSString *)src;  // src may be nil
 {
+    [self startElement:@"script"];
+    
     // HTML5 doesn't need the script type specified, but older doc types do for standards-compliance
     if (![self.doctype isEqualToString:KSHTMLDoctypeHTML_5])
     {
-        [self pushAttribute:@"type" value:@"text/javascript"];
+        [self addAttribute:@"type" value:@"text/javascript"];
     }
     
     // Script
     if (src)
 	{
-		[self pushAttribute:@"src" value:src];
-        [self startElement:@"script"];
+		[self addAttribute:@"src" value:src];
 	}
     else
     {
         // Outdent the script compared to what's normal. Context will take care of placing on a
         // new line for us
-        [self startElement:@"script"];
-        
-		[self decreaseIndentationLevel];
+        [self decreaseIndentationLevel];
 		[self startNewline];
     }
 }
@@ -375,10 +371,10 @@ NSString *KSHTMLDoctypeHTML_5 = @"html";
 
 - (void)writeParamElementWithName:(NSString *)name value:(NSString *)value;
 {
-	if (name) [self pushAttribute:@"name" value:name];
-	if (value) [self pushAttribute:@"value" value:value];
-    [self startElement:@"param"];
-    [self endElement];
+    [self writeElement:@"param" content:^{
+        if (name) [self addAttribute:@"name" value:name];
+        if (value) [self addAttribute:@"value" value:value];
+    }];
 }
 
 #pragma mark Style
@@ -392,8 +388,8 @@ NSString *KSHTMLDoctypeHTML_5 = @"html";
 
 - (void)startStyleElementWithType:(NSString *)type;
 {
-    if (type) [self pushAttribute:@"type" value:type];
     [self startElement:@"style"];
+    if (type) [self addAttribute:@"type" value:type];
 }
 
 #pragma mark Elements Stack

--- a/KSHTMLWriter.m
+++ b/KSHTMLWriter.m
@@ -537,23 +537,21 @@ NSString *KSHTMLDoctypeHTML_5 = @"html";
 
 #pragma mark Element Primitives
 
-- (void)willStartElement:(NSString *)elementName {
+- (void)startElement:(NSString *)elementName {
     
 #ifdef DEBUG
     NSAssert1([elementName isEqualToString:[elementName lowercaseString]], @"Attempt to start non-lowercase element: %@", elementName);
 #endif
     
+    [super startElement:elementName];
     
     // Add in any pre-written classes
     NSString *class = [self currentElementClassName];
     if (class)
     {
         [_classNames removeAllObjects];
-        [super pushAttribute:@"class" value:class];
+        [self addAttribute:@"class" value:class];
     }
-    
-    
-    [super willStartElement:elementName];
 }
 
 - (void)closeEmptyElementTag;               //   />    OR    >    depending on -isXHTML

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -85,6 +85,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Attributes
 
+/**
+ Appends an attribute to the current element. Importantly this ONLY works in the time between an
+ element being started, and the first bit of content being written. For example, this is fine:
+ 
+    [writer startElement:@"foo"];
+    [writer addAttribute:@"bar" value:@"true"];
+    [writer writeCharacters:@"text"];
+ 
+ and so is this:
+ 
+    [writer writeElement:@"foo" content:^{
+        [writer addAttribute:@"foo" value:@"bar"]);
+        [writer writeCharacters:@"text"];
+    }];
+ 
+ But this will throw an exception since the writer has nowhere to add the attribite *to*:
+ 
+    [writer writeElement:@"foo" content:^{
+        [writer writeCharacters:@"text"];
+        [writer addAttribute:@"foo" value:@"bar"]);
+    }];
+ */
+- (void)addAttribute:(NSString *)attribute value:(NSString *)value;
+
 /*  You can also gain finer-grained control over element attributes. KSXMLWriter maintains a list of attributes that will be applied when you *next* call one of the -startElement: methods. This has several advantages:
  *      - Attributes are written in exactly the order you specify
  *      - More efficient than building up a temporary dictionary object

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -68,8 +68,6 @@
 
 - (void)writeElement:(NSString *)name content:(void (^)(void))content;
 
-/* Need to force inline writing? Fall back to the old -startElement… API for now */
-
 // Convenience for writing <tag>text</tag>
 - (void)writeElement:(NSString *)elementName text:(NSString *)text;
 

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -57,10 +57,16 @@
 
 #pragma mark Characters
 
-//  Escapes the string and calls -writeString:. NOT intended for other text-like strings such as element attributes
+/**
+ Escapes any XML entities, passing the results through to \c -writeString:
+ 
+ NOT intended for other text-like strings such as element attributes. Use other APIs for that instead.
+ */
 - (void)writeCharacters:(NSString *)string;
 
-// Convenience to perform escaping without instantiating a writer
+/**
+ Convenience to perform escaping without instantiating a writer.
+ */
 + (NSString *)stringFromCharacters:(NSString *)string;
 
 
@@ -68,7 +74,9 @@
 
 - (void)writeElement:(NSString *)name content:(void (^)(void))content;
 
-// Convenience for writing <tag>text</tag>
+/**
+ Convenience for writing <tag>text</tag>
+ */
 - (void)writeElement:(NSString *)elementName text:(NSString *)text;
 
 - (void)willStartElement:(NSString *)element;
@@ -84,15 +92,28 @@
  *  The stack is cleared for you each time an element starts, to save the trouble of manually managing that.
  */
 - (void)pushAttribute:(NSString *)attribute value:(id)value;
-- (KSXMLAttributes *)currentAttributes; // modifying this object will not affect writing
-- (BOOL)hasCurrentAttributes;           // faster than querying -currentAttributes
 
-// Like +stringFromCharacters: but for attributes, where quotes need to be escaped
+/**
+ @result a copy of the current attributes stack
+ */
+- (KSXMLAttributes *)currentAttributes;
+
+/**
+ Handy way to find if there's any attributes pushed without the overhead of copying \c currentAttributes
+ */
+- (BOOL)hasCurrentAttributes;
+
+/**
+ Like +stringFromCharacters: but for attributes, where quotes need to be escaped
+ */
 + (NSString *)stringFromAttributeValue:(NSString *)value;
 
 
 #pragma mark Comments
-- (void)writeComment:(NSString *)comment;   // escapes the string, and wraps in a comment tag
+/**
+ Writes a comment tag, escaping the text as needed.
+ */
+- (void)writeComment:(NSString *)comment;
 - (void)openComment;
 - (void)closeComment;
 

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -175,9 +175,11 @@
  */
 + (BOOL)shouldPrettyPrintElementInline:(NSString *)element;
 
-
-#pragma mark Indentation
-// Setting the indentation level does not write to the context in any way. It is up to methods that actually do some writing to respect the indent level. e.g. starting a new line should indent that line to match.
+/**
+ The number of tabs to indent by whenever `startNewline` is called. You do not normally need to
+ adjust this property mid-writing as starting/ending elements etc. automatically adjust the level to
+ match.
+ */
 @property(nonatomic) NSUInteger indentationLevel;
 - (void)increaseIndentationLevel;
 

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -41,6 +41,9 @@
 /**
  The document's type, which we hang onto so clients can get some information about the XML being
  written if they need to. Avoid changing this mid-writing as would likely confuse clients.
+ 
+ nil by default, but subclasses might override that. For example, KSHTMLWriter does, to default to
+ the HTML 5 doctype.
  */
 @property(nonatomic, copy) NSString *doctype;
 

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -80,8 +80,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)writeElement:(NSString *)elementName text:(NSString *)text;
 
-- (void)willStartElement:(NSString *)element;
-
 
 #pragma mark Attributes
 

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -64,7 +64,6 @@
 #pragma mark Elements
 
 - (void)writeElement:(NSString *)name content:(void (^)(void))content;
-- (void)writeElement:(NSString *)name attributes:(NSDictionary *)attributes content:(void (^)(void))content;
 
 /* Need to force inline writing? Fall back to the old -startElement… API for now */
 

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -73,7 +73,8 @@
 - (void)willStartElement:(NSString *)element;
 
 
-#pragma mark Current Element
+#pragma mark Attributes
+
 /*  You can also gain finer-grained control over element attributes. KSXMLWriter maintains a list of attributes that will be applied when you *next* call one of the -startElement: methods. This has several advantages:
  *      - Attributes are written in exactly the order you specify
  *      - More efficient than building up a temporary dictionary object
@@ -85,8 +86,6 @@
 - (KSXMLAttributes *)currentAttributes; // modifying this object will not affect writing
 - (BOOL)hasCurrentAttributes;           // faster than querying -currentAttributes
 
-
-#pragma mark Attributes
 // Like +stringFromCharacters: but for attributes, where quotes need to be escaped
 + (NSString *)stringFromAttributeValue:(NSString *)value;
 

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -27,13 +27,14 @@
 
 #import "KSXMLAttributes.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface KSXMLWriter : NSObject
 
 #pragma mark Creating an XML Writer
 
 // .encoding is taken from the writer. If output writer is nil, defaults to UTF-8
-- (id)initWithOutputWriter:(KSWriter *)output NS_DESIGNATED_INITIALIZER;
+- (id)initWithOutputWriter:(nullable KSWriter *)output NS_DESIGNATED_INITIALIZER;
 
 
 #pragma mark Document
@@ -45,7 +46,7 @@
  nil by default, but subclasses might override that. For example, KSHTMLWriter does, to default to
  the HTML 5 doctype.
  */
-@property(nonatomic, copy) NSString *doctype;
+@property(nonatomic, copy, nullable) NSString *doctype;
 
 /**
  Writes a doctype declaration according to the receiver's \c docType, which must be non-nil. Example:
@@ -72,7 +73,7 @@
 
 #pragma mark Elements
 
-- (void)writeElement:(NSString *)name content:(void (^)(void))content;
+- (void)writeElement:(NSString *)name content:(nullable void (^)(void))content;
 
 /**
  Convenience for writing <tag>text</tag>
@@ -211,7 +212,7 @@
 - (NSUInteger)openElementsCount;
 - (BOOL)hasOpenElement:(NSString *)tagName;
 
-- (NSString *)topElement;
+- (nullable NSString *)topElement;
 - (void)pushElement:(NSString *)element;
 - (void)popElement;
 
@@ -245,7 +246,7 @@
 + (BOOL)isStringEncodingAvailable:(NSStringEncoding)encoding;
 
 
-@property(readonly) KSWriter *outputWriter;
+@property(nullable, readonly) KSWriter *outputWriter;
 
 
 #pragma mark -
@@ -261,3 +262,4 @@
 
 @end
 
+NS_ASSUME_NONNULL_END

--- a/KSXMLWriter.h
+++ b/KSXMLWriter.h
@@ -191,7 +191,10 @@
 
 
 #pragma mark Validation
-// Default implementation returns YES. Subclasses can override to advise that the writing of an element would result in invalid markup
+/**
+ Default implementation returns YES. Subclasses can override to advise that the writing of an
+ element would result in invalid markup
+ */
 - (BOOL)validateElement:(NSString *)element;
 - (NSString *)validateAttribute:(NSString *)name value:(NSString *)value ofElement:(NSString *)element;
 
@@ -200,7 +203,10 @@
 #pragma mark Elements Stack
 // XMLWriter maintains a stack of the open elements so it knows how to end them. You probably don't ever care about this, but it can be handy in more advanced use cases
 
-@property(nonatomic, readonly) NSArray *openElements;  // the methods below are faster than this
+/**
+ A copy of the current elements stack
+ */
+@property(nonatomic, readonly) NSArray *openElements;
 
 - (NSUInteger)openElementsCount;
 - (BOOL)hasOpenElement:(NSString *)tagName;

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -600,13 +600,13 @@ static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;
     _prettyPrintingDisabled = NO;
     
     
-    // Write attributes
-    [_attributes writeAttributes:self];
-    [_attributes close];
-    
-    
     // With writing done, begin tracking to see if element is empty
     _yetToCloseStartTag = YES;
+    
+    
+    // Add attributes
+    [_attributes writeAttributes:self];
+    [_attributes close];
     
     
     [self increaseIndentationLevel];
@@ -661,7 +661,7 @@ static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;
     {
         NSString *attribute = [_attributes objectAtIndex:i];
         NSString *value = [_attributes objectAtIndex:i+1];
-        [writer writeAttribute:attribute value:value];
+        [writer addAttribute:attribute value:value];
     }
 }
 

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -158,7 +158,7 @@
     [_openElements removeLastObject];
 }
 
-#pragma mark Current Element
+#pragma mark Attributes
 
 - (void)pushAttribute:(NSString *)attribute value:(id)value; // call before -startElement:
 {
@@ -175,8 +175,6 @@
 {
     return [_attributes count];
 }
-
-#pragma mark Attributes
 
 - (void)writeAttributeValue:(NSString *)value;
 {

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -165,7 +165,15 @@
     if (_yetToCloseStartTag) {
         // Temporarily turn off tracking so the write goes through without triggering closure
         _yetToCloseStartTag = NO;
-        [self writeAttribute:attribute value:value];
+        
+        NSString *valueString = [value description];
+        
+        [self writeString:@" "];
+        [self writeString:attribute];
+        [self writeString:@"=\""];
+        [self writeAttributeValue:valueString];
+        [self writeString:@"\""];
+        
         _yetToCloseStartTag = YES;
     }
     else {
@@ -221,23 +229,6 @@
     }];
     
     return result;
-}
-
-/**
- Performs the raw writing of an attribute and its value:
- 
- \c attribute="value"
- */
-- (void)writeAttribute:(NSString *)attribute
-                 value:(id)value;
-{
-	NSString *valueString = [value description];
-	
-    [self writeString:@" "];
-    [self writeString:attribute];
-    [self writeString:@"=\""];
-    [self writeAttributeValue:valueString];
-    [self writeString:@"\""];
 }
 
 #pragma mark Comments

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -352,16 +352,6 @@
 #pragma mark Element Primitives
 
 /**
- Called each time an element is started. Begins tracking \c -writeString: calls to see if element is empty
- */
-- (void)didStartElement {
-    
-    // For elements which can't be empty, might as well go ahead and close the start tag now
-    _elementIsEmpty = [self elementCanBeEmpty:[self topElement]];
-    if (!_elementIsEmpty) [self closeStartTag];
-}
-
-/**
  Writes the raw \c > character that marks the close of a _tag_ (not the element, the tag)
  */
 - (void)closeStartTag {
@@ -599,7 +589,12 @@ static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;
     [_attributes close];
     
     
-    [self didStartElement];
+    // With writing done, begin tracking \c -writeString: calls to see if element is empty
+    // For elements which can't be empty, might as well go ahead and close the start tag now
+    _elementIsEmpty = [self elementCanBeEmpty:elementName];
+    if (!_elementIsEmpty) [self closeStartTag];
+    
+    
     [self increaseIndentationLevel];
 }
 

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -41,6 +41,9 @@
 @implementation KSXMLWriter {
     KSXMLAttributes   *_attributes;
     NSMutableArray  *_openElements;
+    
+    /// Tracks whether the current element's start tag is yet to be closed, so we know later if need
+    /// to write an end tag, or can have a single <foo /> type of tag
     BOOL            _elementIsEmpty;
     
     // Pretty printing

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -133,17 +133,6 @@
     [self endElement];
 }
 
-- (void)writeElement:(NSString *)name attributes:(NSDictionary *)attributes content:(void (^)(void))content;
-{
-    for (NSString *aName in attributes)
-    {
-        NSString *aValue = [attributes objectForKey:aName];
-        [self pushAttribute:aName value:aValue];
-    }
-    
-    [self writeElement:name content:content];
-}
-
 - (void)writeElement:(NSString *)elementName text:(NSString *)text;
 {
     [self writeElement:elementName content:^{

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -587,10 +587,8 @@ static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;
     [_attributes close];
     
     
-    // With writing done, begin tracking \c -writeString: calls to see if element is empty
-    // For elements which can't be empty, might as well go ahead and close the start tag now
-    _elementIsEmpty = [self elementCanBeEmpty:elementName];
-    if (!_elementIsEmpty) [self closeStartTag];
+    // With writing done, begin tracking to see if element is empty
+    _elementIsEmpty = YES;
     
     
     [self increaseIndentationLevel];
@@ -603,7 +601,8 @@ static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;
     
     
     // Write the tag itself.
-    if (_elementIsEmpty)
+    NSString *element = self.topElement;
+    if (_elementIsEmpty && [self elementCanBeEmpty:element])
     {
         [self popElement];  // turn off _elementIsEmpty first or regular start tag will be written!
         [self closeEmptyElementTag];
@@ -615,7 +614,7 @@ static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;
             [self startNewline];   // was this element written entirely inline?
         }
         
-        [self writeEndTag:[self topElement]];
+        [self writeEndTag:element];
         [self popElement];
     }
 }

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -143,8 +143,6 @@
     }];
 }
 
-- (void)willStartElement:(NSString *)element; { /* for subclassers */ }
-
 - (void)pushElement:(NSString *)element;
 {
     // Private method so that Sandvox can work for now
@@ -576,9 +574,6 @@ static NSCharacterSet *sCharactersToEntityEscapeWithoutQuot;
     if ([self shouldBeginNewlineForElement:elementName]) {
         [self startNewline];
     }
-    
-    // Warn of impending start
-    [self willStartElement:elementName];
     
     [self writeString:@"<"];
     [self writeString:elementName];

--- a/Tests/Classes/KSXMLWriterCompoundTests.m
+++ b/Tests/Classes/KSXMLWriterCompoundTests.m
@@ -52,7 +52,11 @@
         NSString* element = [action objectForKey:@"element"];
         if (element)
         {
-            [writer writeElement:element attributes:attributes content:^{
+            [attributes enumerateKeysAndObjectsUsingBlock:^(NSString *attribute, id value, BOOL *stop) {
+                [writer pushAttribute:attribute value:value];
+            }];
+            
+            [writer writeElement:element content:^{
                 [self writer:writer performActions:content];
             }];
         }

--- a/Tests/Classes/KSXMLWriterTests.m
+++ b/Tests/Classes/KSXMLWriterTests.m
@@ -104,6 +104,16 @@
     }];
 }
 
+- (void)testEmptyElementWithAttribute
+{
+    [writer writeElement:@"foo" content:^{
+        [writer addAttribute:@"wobble" value:@"wibble"];
+    }];
+    
+    NSString* generated = [output string];
+    XCTAssertEqualObjects(generated, @"<foo wobble=\"wibble\" />");
+}
+
 - (void)testPushAttribute
 {
     [writer pushAttribute:@"a1" value:@"v1"];

--- a/Tests/Classes/KSXMLWriterTests.m
+++ b/Tests/Classes/KSXMLWriterTests.m
@@ -67,9 +67,9 @@
 
 - (void)testWriteElementOneAttribute
 {
-    [writer pushAttribute:@"wobble" value:@"wibble"];
-    
     [writer writeElement:@"foo" content:^{
+        [writer addAttribute:@"wobble" value:@"wibble"];
+        
         [writer writeCharacters:@"bar"];
     }];
     
@@ -79,15 +79,29 @@
 
 - (void)testWriteElementMultipleAttributes
 {
-    [writer pushAttribute:@"k2" value:@"o2"];
-    [writer pushAttribute:@"k1" value:@"o1"];
-    
     [writer writeElement:@"foo" content:^{
+        [writer addAttribute:@"k2" value:@"o2"];
+        [writer addAttribute:@"k1" value:@"o1"];
+        
         [writer writeCharacters:@"bar"];
     }];
     
     NSString* generated = [output string];
     XCTAssertEqualObjects(generated, @"<foo k2=\"o2\" k1=\"o1\">bar</foo>");
+}
+
+- (void)testAddingAttributeTooEarly {
+    
+    XCTAssertThrows([writer addAttribute:@"foo" value:@"bar"]);
+}
+
+- (void)testAddingAttributeTooLate {
+    
+    [writer writeElement:@"foo" content:^{
+        [writer writeCharacters:@"text"];
+        
+        XCTAssertThrows([writer addAttribute:@"foo" value:@"bar"]);
+    }];
 }
 
 - (void)testPushAttribute

--- a/Tests/Classes/KSXMLWriterTests.m
+++ b/Tests/Classes/KSXMLWriterTests.m
@@ -40,7 +40,7 @@
 
 - (void)testWriteElementNoContent
 {
-    [writer writeElement:@"foo" attributes:nil content:nil];
+    [writer writeElement:@"foo" content:nil];
     
     NSString* generated = [output string];
     XCTAssertEqualObjects(generated, @"<foo />");
@@ -48,7 +48,7 @@
 
 - (void)testWriteElementEmptyContent
 {
-    [writer writeElement:@"foo" attributes:nil content:^{
+    [writer writeElement:@"foo" content:^{
     }];
     
     NSString* generated = [output string];
@@ -57,7 +57,7 @@
 
 - (void)testWriteElementNoAttributes
 {
-    [writer writeElement:@"foo" attributes:nil content:^{
+    [writer writeElement:@"foo" content:^{
          [writer writeCharacters:@"bar"];
      }];
     
@@ -65,21 +65,11 @@
     XCTAssertEqualObjects(generated, @"<foo>bar</foo>");
 }
 
-- (void)testWriteElementEmptyAttributes
-{
-    NSDictionary* attributes = [NSDictionary dictionary];
-    [writer writeElement:@"foo" attributes:attributes content:^{
-        [writer writeCharacters:@"bar"];
-    }];
-    
-    NSString* generated = [output string];
-    XCTAssertEqualObjects(generated, @"<foo>bar</foo>");
-}
-
 - (void)testWriteElementOneAttribute
 {
-    NSDictionary* attributes = [NSDictionary dictionaryWithObject:@"wibble" forKey:@"wobble"];
-    [writer writeElement:@"foo" attributes:attributes content:^{
+    [writer pushAttribute:@"wobble" value:@"wibble"];
+    
+    [writer writeElement:@"foo" content:^{
         [writer writeCharacters:@"bar"];
     }];
     
@@ -89,8 +79,10 @@
 
 - (void)testWriteElementMultipleAttributes
 {
-    NSDictionary* attributes = [NSDictionary dictionaryWithObjectsAndKeys:@"o1", @"k1", @"o2", @"k2", nil];
-    [writer writeElement:@"foo" attributes:attributes content:^{
+    [writer pushAttribute:@"k2" value:@"o2"];
+    [writer pushAttribute:@"k1" value:@"o1"];
+    
+    [writer writeElement:@"foo" content:^{
         [writer writeCharacters:@"bar"];
     }];
     
@@ -110,7 +102,7 @@
     attributeCount = [[writer currentAttributes] count];
     XCTAssertEqual(attributeCount, (NSUInteger) 2, @"wrong number of attributes");
     
-    [writer writeElement:@"foo" attributes:nil content:^{
+    [writer writeElement:@"foo" content:^{
         [writer writeCharacters:@"bar"];
     }];
         
@@ -126,7 +118,7 @@
 - (void)testWriteEscapedEntities
 {
     // TODO could expand this to include a list of all entities
-    [writer writeElement:@"foo" attributes:nil content:^{
+    [writer writeElement:@"foo" content:^{
         [writer writeCharacters:@"< & >"];
     }];
     
@@ -146,7 +138,7 @@
     // TODO could expand this to loop through all characters, but some of them will expand
     // to unexpected things - e.g. see character 160 below...
 
-    [writer writeElement:@"foo" attributes:nil content:^{
+    [writer writeElement:@"foo" content:^{
         
         // write some random non-ascii characters
         // (160 happens to be a non-breaking space, so it will be encoded as nbsp;)
@@ -163,7 +155,7 @@
 - (void)testWriteComment
 {
     // TODO could expand this to include a list of all entities
-    [writer writeElement:@"foo" attributes:nil content:^{
+    [writer writeElement:@"foo" content:^{
         [writer writeComment:@"this is a comment"];
         [writer writeCharacters:@"this is not a comment"];
         [writer writeComment:@"this is another comment"];
@@ -177,7 +169,7 @@
 {
     writer.doctype = @"some-type";
     [writer writeDoctypeDeclaration];
-    [writer writeElement:@"foo" attributes:nil content:^{
+    [writer writeElement:@"foo" content:^{
         [writer writeCharacters:@"bar"];
     }];
     


### PR DESCRIPTION
Time for a new API. The existing API means calls to the writer are often out of order compared to the output:

```
[writer pushAttribute:@“id” value:@“main”];
[writer startElement:@"div"];
// …write your content
```

This new API allows things to happen in their logical order:

```
[writer startElement:@"div"];
[writer addAttribute:@“id” value:@“main”];
// …write your content
```

It’s a little more picky. You can only do this in between starting the element and writing the first bit of content. Anything later than that has nowhere to write to, so throws an exception.

I’ve also done a bunch of cleanup on the header, docs and nullability
