### PR TITLE
Improve newline handling when mixing in raw strings

### DIFF
--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -132,25 +132,25 @@
     // We've reached the end of the element, so of course indentation needs to decrease
     [self decreaseIndentationLevel];
     
-    
-    // Write the tag itself.
+    // and same goes for the stack
     NSString *element = self.topElement;
-    if (_yetToCloseStartTag && [self elementCanBeEmpty:element])
-    {
-        [self popElement];  // turn off _elementIsEmpty first or regular start tag will be written!
+    [self popElement];
+    
+    
+    // Write the tag itself, as a special empty one if we should
+    if (_yetToCloseStartTag && [self elementCanBeEmpty:element]) {
+        
+        _yetToCloseStartTag = NO;
         [self closeEmptyElementTag];
+        return;
     }
-    else
-    {
-        [self popElement];
-        
-        // Did that element span multiple lines? If so, the end tag ought to go on its own line
-        if (self.openElementsCount < _elementCountAtLastNewline) {
-            [self startNewline];   // was this element written entirely inline?
-        }
-        
-        [self writeEndTag:element];
+    
+    // Did that element span multiple lines? If so, the end tag ought to go on its own line
+    if (self.openElementsCount < _elementCountAtLastNewline) {
+        [self startNewline];   // was this element written entirely inline?
     }
+    
+    [self writeEndTag:element];
 }
 
 - (void)writeElement:(NSString *)name content:(void (^)(void))content;
@@ -175,8 +175,6 @@
 
 - (void)popElement;
 {
-    _yetToCloseStartTag = NO;
-    
     [_openElements removeLastObject];
 }
 

--- a/KSXMLWriter.m
+++ b/KSXMLWriter.m
@@ -142,13 +142,14 @@
     }
     else
     {
+        [self popElement];
+        
         // Did that element span multiple lines? If so, the end tag ought to go on its own line
-        if (self.openElementsCount - 1 < _elementCountAtLastNewline) {
+        if (self.openElementsCount < _elementCountAtLastNewline) {
             [self startNewline];   // was this element written entirely inline?
         }
         
         [self writeEndTag:element];
-        [self popElement];
     }
 }
 

--- a/Tests/Classes/KSHTMLWriterTests.m
+++ b/Tests/Classes/KSHTMLWriterTests.m
@@ -67,4 +67,57 @@
                           @"The </script> tag goes down onto its own line too");
 }
 
+/**
+ This is an example similar to something in Sandvox where you have some stuff followed by a
+ complicated header (i.e. it's got an element nested in it). This is the pure version which works ok
+ as-is, but I want to keep the test around.
+ */
+- (void)testPrettyPrinting {
+    
+    [writer writeElement:@"div" content:^{
+        [writer writeElement:@"p" text:@"Text"];
+    }];
+    
+    [writer writeElement:@"h2" content:^{
+        [writer writeElement:@"span" text:@"Subheading"];
+    }];
+    
+    XCTAssertEqualObjects(output.string,
+                          @"<div>\n\t<p>Text</p>\n</div>\n"
+                          @"<h2><span>Subheading</span></h2>");
+}
+
+/**
+ …and now we try it again, but this time mimicking some of the content coming from a source other
+ than nice writer commands. e.g. a template
+ */
+- (void)testPrettyPrintingAfterTemplate {
+    
+    // Some template stuff…
+    [writer writeString:@"TEMPLATE START\n"];
+    
+    // …contains a direct bit of content
+    [writer writeElement:@"div" content:^{
+        [writer writeElement:@"h4" text:@"Title"];
+    }];
+    
+    // Then goes back to the template
+    [writer writeString:@"\n"];
+    [writer writeString:@"TEMPLATE END\n"];
+    
+    // And now it's time to write the next thing
+    [writer resetPrettyPrinting];
+    [writer writeElement:@"h2" content:^{
+        [writer writeElement:@"span" text:@"Subheading"];
+    }];
+    
+    XCTAssertEqualObjects(output.string,
+                          @"TEMPLATE START\n"
+                          @"<div>\n"
+                          @"\t<h4>Title</h4>\n"
+                          @"</div>\n"
+                          @"TEMPLATE END\n"
+                          @"<h2><span>Subheading</span></h2>");
+}
+
 @end

--- a/Tests/Classes/KSHTMLWriterTests.m
+++ b/Tests/Classes/KSHTMLWriterTests.m
@@ -120,4 +120,13 @@
                           @"<h2><span>Subheading</span></h2>");
 }
 
+- (void)testEmptyElement {
+    
+    [writer writeElement:@"style" idName:@"paragraph-styles" className:nil content:^{
+        
+    }];
+    
+    XCTAssertEqualObjects(output.string, @"<style id=\"paragraph-styles\"></style>");
+}
+
 @end


### PR DESCRIPTION
I found that if you go from one element to another by manually writing newlines — likely because there’s some kind of template providing them — the newline tracking system gets out of whack. It holds onto an old value, and later causes another element to weirdly jump onto an extra line unexpectedly.
